### PR TITLE
Fix templaterenderer

### DIFF
--- a/autosuggest-demo/frontend/vcf-autosuggest.js
+++ b/autosuggest-demo/frontend/vcf-autosuggest.js
@@ -152,7 +152,7 @@ import './vcf-autosuggest-overlay';
                                             padding-right: 0.5em;
                                         }
                                     </style>
-                                    <div id="autosuggestOverlayItem{{option.optId}}" part="option" data-tag="autosuggestOverlayItem" data-oid="{{option.optId}}" data-key="{{option.key}}"></div>
+                                    <vaadin-item on-click="_optionClicked" part="option" data-tag="autosuggestOverlayItem" data-oid="{{option.optId}}" data-key="{{option.key}}"></vaadin-item>
                                 </template>
                             </template>
                         </template>


### PR DESCRIPTION
With this it is possible to use the templaterenderer as part of vaadin-item

```
suggest.setTemplateProvider("function(option, that) { return `"
			+ "${option.listItem}"
			+ "`;}");
```

as such it is possible to navigate through the suggestions using the arrow keys